### PR TITLE
Fix README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Sticker Cannon
+# Sticker Cannon
 A tool for printing address labels using a DYMO LabelWriter 450 Label Printer
 
 ### Environment Variables


### PR DESCRIPTION
Previously, there was not a space between the `#` and the title, which resulted in a not-formatted title. This PR just adds a space, so it appears as a title.

Sticker Cannon is so coooooool :0